### PR TITLE
Rewrite the attribute value (unix timestamp) to a datetime

### DIFF
--- a/src/DateTimePicker.php
+++ b/src/DateTimePicker.php
@@ -94,6 +94,9 @@ class DateTimePicker extends InputWidget
      */
     public function run()
     {
+        if($this->hasModel()){
+            $this->model->{$this->attribute} = \Yii::$app->formatter->asDatetime($this->model->{$this->attribute});
+        }
 
         $input = $this->hasModel()
             ? Html::activeTextInput($this->model, $this->attribute, $this->options)

--- a/tests/functional/DateTimePickerTest.php
+++ b/tests/functional/DateTimePickerTest.php
@@ -20,7 +20,7 @@ class DateTimePickerTest extends TestCase
             'model' => $model,
             'attribute' => 'create_time'
         ]);
-        $expected = '<div class="input-group date"><input type="text" id="post-create_time" class="form-control" name="Post[create_time]" value="1425807308" readonly="readonly"><span class="input-group-addon"><span class="glyphicon glyphicon-remove"></span></span><span class="input-group-addon"><span class="glyphicon glyphicon-th"></span></span></div>';
+        $expected = '<div class="input-group date"><input type="text" id="post-create_time" class="form-control" name="Post[create_time]" value="Mar 8, 2015 9:35:08 AM" readonly="readonly"><span class="input-group-addon"><span class="glyphicon glyphicon-remove"></span></span><span class="input-group-addon"><span class="glyphicon glyphicon-th"></span></span></div>';
 
         $this->assertEqualsWithoutLE($expected, $out);
     }


### PR DESCRIPTION
If this is not done the input field shows the unix timestamp.
This is useless for the client side scripts.

This implementation assumes that the global (yii) datetime format is equivalent to the 'clientOptions' format.