### PR TITLE
Added ability to change readonly attribute

### DIFF
--- a/src/DateTimePicker.php
+++ b/src/DateTimePicker.php
@@ -65,6 +65,10 @@ class DateTimePicker extends InputWidget
      * @var bool whether to render the input as an inline calendar
      */
     public $inline = false;
+    /**
+     * @var bool whether to add readonly attribute
+     */
+    public $readonly = true;
 
     /**
      * @inheritdoc
@@ -75,7 +79,8 @@ class DateTimePicker extends InputWidget
 
         Html::addCssClass($this->containerOptions, 'input-group date');
         Html::addCssClass($this->options, 'form-control');
-        $this->options['readonly'] = 'readonly';
+        if ($this->readonly)
+            $this->options['readonly'] = 'readonly';
         if ($this->size !== null) {
             $size = 'input-' . $this->size;
             Html::addCssClass($this->options, $size);


### PR DESCRIPTION
By default `$this->options['readonly'] = 'readonly';`, but when we don't need __readonly__ attribute we always have to extend this class and override `init` method
```
public function init()
{
    parent::init();
    unset($this->options['readonly']);
}
```
That's why I added `public $readonly = true;` attribute, to have ability set __readonly__ to __false__ if needed:
```
<?= DateTimePicker::widget([
...
 'readonly' => false,
...
]);?>
```