### PR TITLE
Added when language is not passed set to one in Yii::$app->language

### DIFF
--- a/src/DateTimePicker.php
+++ b/src/DateTimePicker.php
@@ -128,15 +128,11 @@ class DateTimePicker extends InputWidget
         $view = $this->getView();
 
         // @codeCoverageIgnoreStart
-        if ($this->language !== null) {
-            $this->clientOptions['language'] = $this->language;
-            DateTimePickerAsset::register(
-                $view
-            )->js[] = 'js/locales/bootstrap-datetimepicker.' . $this->language . '.js';
-        } else {
-            $this->clientOptions['language'] = Yii::$app->language;
-            DateTimePickerAsset::register($view);
-        }
+        $this->language = $this->language !== null ? $this->language : \Yii::$app->language;
+        $this->clientOptions['language'] = $this->language;
+        DateTimePickerAsset::register(
+            $view
+        )->js[] = 'js/locales/bootstrap-datetimepicker.' . $this->language . '.js';
         // @codeCoverageIgnoreEnd
 
         $id = $this->options['id'];

--- a/src/DateTimePicker.php
+++ b/src/DateTimePicker.php
@@ -134,6 +134,7 @@ class DateTimePicker extends InputWidget
                 $view
             )->js[] = 'js/locales/bootstrap-datetimepicker.' . $this->language . '.js';
         } else {
+            $this->clientOptions['language'] = Yii::$app->language;
             DateTimePickerAsset::register($view);
         }
         // @codeCoverageIgnoreEnd


### PR DESCRIPTION
When `$this->language` is `null` and not passed as:
```
<?= DateTimePicker::widget([
...
 'language' => 'some language',
...
]);?>
```
in  `$this->clientOptions['language']` it's set as some default value, but there is `Yii::$app->language` which is better to use as default language.