### PR TITLE
disable loading of bootstrap asset

### DIFF
--- a/src/DateTimePickerAsset.php
+++ b/src/DateTimePickerAsset.php
@@ -28,6 +28,6 @@ class DateTimePickerAsset extends AssetBundle
     ];
 
     public $depends = [
-        'yii\bootstrap\BootstrapPluginAsset'
+        //'yii\bootstrap\BootstrapPluginAsset'
     ];
 }


### PR DESCRIPTION
newest version of yii2 includes bs4

this depends loads bs css two times and creates errors